### PR TITLE
Make the path to roms relative.

### DIFF
--- a/deep_q_rl/ale_run.py
+++ b/deep_q_rl/ale_run.py
@@ -13,7 +13,8 @@ import sys
 import os
 import argparse
 
-ROM_PATH = "/home/spragunr/neural_rl_libraries/roms/breakout.bin"
+# Put your binaries under the directory 'deep_q_rl/roms'
+ROM_PATH = "../roms/breakout.bin"
 
 # Check for glue_port command line argument and set it up...
 parser = argparse.ArgumentParser(description='Neural rl agent.')


### PR DESCRIPTION
Here you previously used a directory that mentions your particular setting. Substitute it by a relative directory so it works for everybody. Also, suggest at the read file to create a 'rome' directory with 'breakout.bin' in it.