### PR TITLE
c01b should be set to True only when dimshuffle is False.

### DIFF
--- a/deep_q_rl/q_network.py
+++ b/deep_q_rl/q_network.py
@@ -213,7 +213,7 @@ class DeepQLearner:
             filter_size=(8, 8),
             stride=(4, 4),
             nonlinearity=lasagne.nonlinearities.rectify,
-            W=lasagne.init.HeUniform(c01b=True), # Defaults to Glorot
+            W=lasagne.init.HeUniform(), # Defaults to Glorot
             b=lasagne.init.Constant(.1),
             dimshuffle=True
         )
@@ -224,7 +224,7 @@ class DeepQLearner:
             filter_size=(4, 4),
             stride=(2, 2),
             nonlinearity=lasagne.nonlinearities.rectify,
-            W=lasagne.init.HeUniform(c01b=True),
+            W=lasagne.init.HeUniform(),
             b=lasagne.init.Constant(.1),
             dimshuffle=True
         )
@@ -235,7 +235,7 @@ class DeepQLearner:
             filter_size=(3, 3),
             stride=(1, 1),
             nonlinearity=lasagne.nonlinearities.rectify,
-            W=lasagne.init.HeUniform(c01b=True),
+            W=lasagne.init.HeUniform(),
             b=lasagne.init.Constant(.1),
             dimshuffle=True
         )


### PR DESCRIPTION
At least according to what I get from Lasagne's documentation (http://lasagne.readthedocs.org/en/latest/modules/init.html )

c01b : bool

For a lasagne.layers.cuda_convnet.Conv2DCCLayer constructed with dimshuffle=False, c01b must be set to True to compute the correct fan-in and fan-out.

but since you are using dimshuffle=True, each layer is doing the automatic shuffling/deshuffling, so the initialiser sees the "correct" number of incoming nodes, no? From looking at the code, fan_in = np.prod(shape[:3]) when c01b is True, and fan_in = np.prod(shape[1:]) otherwise. 

(also, maybe the 'gain' should be set to 'relu' to multiply it by sqrt(2).  ( Not that I understand why that should be the case))