### PR TITLE
Don't count unfinished games towards the average score for the epoch

### DIFF
--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -125,6 +125,7 @@ class NeuralAgent(object):
 
         self.step_counter = 0
         self.batch_counter = 0
+        self.episode_reward = 0
 
         # We report the mean loss for every epoch.
         self.loss_averages = []
@@ -168,7 +169,7 @@ class NeuralAgent(object):
 
         #TESTING---------------------------
         if self.testing:
-            self.total_reward += reward
+            self.episode_reward += reward
             action = self._choose_action(self.test_data_set, .05,
                                          observation, np.clip(reward, -1, 1))
 
@@ -227,22 +228,27 @@ class NeuralAgent(object):
                                   next_states, terminals)
 
 
-    def end_episode(self, reward):
+    def end_episode(self, reward, terminal=True):
         """
         This function is called once at the end of an episode.
 
         Arguments:
            reward      - Real valued reward.
+           terminal    - Whether the game ended intrinsically (ie we didn't run out of time steps)
 
         Returns:
             None
         """
-        self.episode_counter += 1
+        
+        self.episode_reward += reward
         self.step_counter += 1
         total_time = time.time() - self.start_time
 
         if self.testing:
-            self.total_reward += reward
+            # if we run out of time, only count the last episode if it was the only episode
+            if terminal or self.episode_counter == 0:
+                self.episode_counter += 1
+                self.total_reward += self.episode_reward
         else:
 
             # Store the latest sample.

--- a/deep_q_rl/ale_experiment.py
+++ b/deep_q_rl/ale_experiment.py
@@ -98,7 +98,7 @@ class ALEExperiment(object):
             num_steps += 1
 
             if terminal or num_steps >= max_steps:
-                self.agent.end_episode(reward)
+                self.agent.end_episode(reward, terminal)
                 break
 
             action = self.agent.step(reward, self.get_image())


### PR DESCRIPTION
The current code doesn't distinguish between games that finished due to natural causes or due to the epoch running out of frames. This means that partial games get counted in the average score for the epoch. This makes little difference for most games, since they are quite short, but it can make a biggish difference to something like enduro that runs for over 10000 frames.

The patch fixes this by telling the agent why the game is finishing, and the agent only counting the episode's score if it's not by running out of time (unless that's the only episode we got)