### PR TITLE
Added deterministic options

### DIFF
--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -11,7 +11,6 @@ import cPickle
 import time
 import logging
 
-import random
 import numpy as np
 
 import ale_data_set
@@ -20,11 +19,10 @@ import sys
 sys.setrecursionlimit(10000)
 
 class NeuralAgent(object):
-    randGenerator = random.Random()
 
     def __init__(self, q_network, epsilon_start, epsilon_min,
                  epsilon_decay, replay_memory_size, exp_pref,
-                 replay_start_size, update_frequency):
+                 replay_start_size, update_frequency, rng):
 
         self.network = q_network
         self.epsilon_start = epsilon_start
@@ -34,6 +32,8 @@ class NeuralAgent(object):
         self.exp_pref = exp_pref
         self.replay_start_size = replay_start_size
         self.update_frequency = update_frequency
+        self.rng = rng
+        
         self.phi_length = self.network.num_frames
         self.image_width = self.network.input_width
         self.image_height = self.network.input_height
@@ -52,13 +52,13 @@ class NeuralAgent(object):
         self.num_actions = self.network.num_actions
 
 
-        self.data_set = ale_data_set.DataSet(width=self.image_width,
+        self.data_set = ale_data_set.DataSet(rng, width=self.image_width,
                                              height=self.image_height,
                                              max_steps=self.replay_memory_size,
                                              phi_length=self.phi_length)
 
         # just needs to be big enough to create phi's
-        self.test_data_set = ale_data_set.DataSet(width=self.image_width,
+        self.test_data_set = ale_data_set.DataSet(rng, width=self.image_width,
                                                   height=self.image_height,
                                                   max_steps=self.phi_length * 2,
                                                   phi_length=self.phi_length)
@@ -131,7 +131,7 @@ class NeuralAgent(object):
         self.loss_averages = []
 
         self.start_time = time.time()
-        return_action = self.randGenerator.randint(0, self.num_actions-1)
+        return_action = self.rng.randint(0, self.num_actions-1)
 
         self.last_action = return_action
 
@@ -211,7 +211,7 @@ class NeuralAgent(object):
             phi = data_set.phi(cur_img)
             action = self.network.choose_action(phi, epsilon)
         else:
-            action = self.randGenerator.randint(0, self.num_actions - 1)
+            action = self.rng.randint(0, self.num_actions - 1)
 
         return action
 

--- a/deep_q_rl/ale_data_set.py
+++ b/deep_q_rl/ale_data_set.py
@@ -18,7 +18,7 @@ class DataSet(object):
     """ Class represents a data set that stores a fixed-length history.
     """
 
-    def __init__(self, width, height, max_steps=1000, phi_length=4,
+    def __init__(self, rng, width, height, max_steps=1000, phi_length=4,
                  capacity=None):
         """  Construct a DataSet.
 
@@ -29,6 +29,7 @@ class DataSet(object):
             capacity - amount of memory to allocate (just for debugging.)
         """
 
+        self.rng = rng
         self.count = 0
         self.max_steps = max_steps
         self.phi_length = phi_length
@@ -145,7 +146,7 @@ class DataSet(object):
 
         # Grab random samples until we have enough
         while count < batch_size:
-            index = np.random.randint(self._min_index(), self._max_index()+1)
+            index = self.rng.randint(self._min_index(), self._max_index()+1)
             end_index = index + self.phi_length - 1
             if self.single_episode(index, end_index):
                 states[count, ...] = self._make_phi(index)

--- a/deep_q_rl/ale_experiment.py
+++ b/deep_q_rl/ale_experiment.py
@@ -6,7 +6,6 @@ Author: Nathan Sprague
 """
 import logging
 import numpy as np
-import random
 import cv2
 
 # Number of rows to crop off the bottom of the (downsampled) screen.
@@ -18,7 +17,7 @@ CROP_OFFSET = 8
 class ALEExperiment(object):
     def __init__(self, ale, agent, resized_width, resized_height,
                  resize_method, num_epochs, epoch_length, test_length,
-                 frame_skip, death_ends_episode, max_start_nullops):
+                 frame_skip, death_ends_episode, max_start_nullops, rng):
         self.ale = ale
         self.agent = agent
         self.num_epochs = num_epochs
@@ -42,6 +41,7 @@ class ALEExperiment(object):
 
         self.terminal_lol = False # Most recent episode ended on a loss of life
         self.max_start_nullops = max_start_nullops
+        self.rng = rng
 
     def run(self):
         """
@@ -89,7 +89,7 @@ class ALEExperiment(object):
             self.ale.reset_game()
 
             if self.max_start_nullops > 0:
-                random_actions = random.randint(0, self.max_start_nullops)
+                random_actions = self.rng.randint(0, self.max_start_nullops)
                 for _ in range(random_actions):
                     self._act(0) # Null action
 
@@ -152,7 +152,6 @@ class ALEExperiment(object):
                 break
 
             action = self.agent.step(reward, self.get_observation())
-
         return terminal, num_steps
 
 

--- a/deep_q_rl/q_network.py
+++ b/deep_q_rl/q_network.py
@@ -29,7 +29,7 @@ class DeepQLearner:
                  num_frames, discount, learning_rate, rho,
                  rms_epsilon, momentum, clip_delta, freeze_interval,
                  batch_size, network_type, update_rule,
-                 batch_accumulator, input_scale=255.0):
+                 batch_accumulator, rng, input_scale=255.0):
 
         self.input_width = input_width
         self.input_height = input_height
@@ -43,6 +43,9 @@ class DeepQLearner:
         self.momentum = momentum
         self.clip_delta = clip_delta
         self.freeze_interval = freeze_interval
+        self.rng = rng
+        
+        lasagne.random.set_rng(self.rng)
 
         self.update_counter = 0
 
@@ -81,6 +84,7 @@ class DeepQLearner:
             broadcastable=(False, True))
 
         q_vals = lasagne.layers.get_output(self.l_out, states / input_scale)
+        
         if self.freeze_interval > 0:
             next_q_vals = lasagne.layers.get_output(self.next_l_out,
                                                     next_states / input_scale)
@@ -105,7 +109,7 @@ class DeepQLearner:
         else:
             raise ValueError("Bad accumulator: {}".format(batch_accumulator))
 
-        params = lasagne.layers.helper.get_all_params(self.l_out)
+        params = lasagne.layers.helper.get_all_params(self.l_out)  
         givens = {
             states: self.states_shared,
             next_states: self.next_states_shared,
@@ -193,8 +197,8 @@ class DeepQLearner:
         return self._q_vals()[0]
 
     def choose_action(self, state, epsilon):
-        if np.random.rand() < epsilon:
-            return np.random.randint(0, self.num_actions)
+        if self.rng.rand() < epsilon:
+            return self.rng.randint(0, self.num_actions)
         q_vals = self.q_vals(state)
         return np.argmax(q_vals)
 

--- a/deep_q_rl/run_nature.py
+++ b/deep_q_rl/run_nature.py
@@ -58,6 +58,8 @@ class Defaults:
     RESIZED_HEIGHT = 84
     DEATH_ENDS_EPISODE = 'true'
     MAX_START_NULLOPS = 30
-
+    DETERMINISTIC = True
+    CUDNN_DETERMINISTIC = False
+    
 if __name__ == "__main__":
     launcher.launch(sys.argv[1:], Defaults, __doc__)

--- a/deep_q_rl/run_nips.py
+++ b/deep_q_rl/run_nips.py
@@ -53,6 +53,8 @@ class Defaults:
     RESIZED_HEIGHT = 84
     DEATH_ENDS_EPISODE = 'false'
     MAX_START_NULLOPS = 0
+    DETERMINISTIC = True
+    CUDNN_DETERMINISTIC = False
 
 if __name__ == "__main__":
     launcher.launch(sys.argv[1:], Defaults, __doc__)


### PR DESCRIPTION
I've added parameters to control reproducibility of the model following #33 :
- DETERMINISTIC sets seed for ALE, Lasagne and numpy 
- CUDNN_DETERMINISTIC allows to use deterministic backprop when using cuDNN. It's a separate parameter, since it slows down the learning by almost a factor of 2, while the models with non-deterministic backprop should not theoretically be very different in the long run.

The PR requires the following:
The latest version of Lasagne, Theano and cuDNN v3.