### PR TITLE
Small bug fix for mean_q

### DIFF
--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -290,7 +290,7 @@ class NeuralAgent(object):
         holdout_sum = 0
         if self.holdout_data is not None:
             for i in range(holdout_size):
-                holdout_sum += np.mean(
+                holdout_sum += np.max(
                     self.network.q_vals(self.holdout_data[i, ...]))
 
         self._update_results_file(epoch, self.episode_counter,


### PR DESCRIPTION
I've noticed inconsistency of how mean_q is evaluated compared to Deepmind code.

According to these lines:
https://github.com/soumith/deepmind-atari/blob/master/dqn/NeuralQLearner.lua#L204
https://github.com/soumith/deepmind-atari/blob/master/dqn/NeuralQLearner.lua#L295
Deepmind code v_avg is calculating average over maximum of Q values, while deep_q_rl implementation calculates average over mean of Q values.
If it wasn't the intention, we should correct it in order to get consistent action values with what we can see in the Nature paper.
