### PR TITLE
dump json parameters with each run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 roms
+utils
+data

--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -120,9 +120,6 @@ class NeuralAgent(AgentBase):
         param_list = [getattr(self.params, attr) \
             for attr in dir(self.params) \
             if isinstance(getattr(self.params, attr), (int, float, str))]
-        print(param_list, type(param_list))
-        for x in param_list:
-            print(type(x), isinstance(x, (int, float, str)))
         json.dump(param_list, self.params_file)
         self.params_file.close()
 

--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -8,7 +8,7 @@ Author: Nathan Sprague
 
 import os
 import cPickle
-import time
+import datetime
 import logging
 import json
 
@@ -103,11 +103,9 @@ class NeuralAgent(AgentBase):
     # region Dumping/Logging
     def _create_export_dir(self):
         # CREATE A FOLDER TO HOLD RESULTS
-        time_str = time.strftime("_%m-%d-%H-%M_", time.gmtime())
-        export_dir = self.exp_pref + time_str + \
-                     "{}".format(self.params.learning_rate).replace(".", "p") \
-                     + "_" + \
-                     "{}".format(self.params.discount).replace(".", "p")
+        # this is now just exp_pref + timestamp. params are in params.json
+        time_str = datetime.datetime.now().strftime("_%m-%d-%H%M_%S_%f")
+        export_dir = self.exp_pref + time_str
         try:
             os.stat(export_dir)
         except OSError:
@@ -316,7 +314,8 @@ class NeuralAgent(AgentBase):
 
     def finish_epoch(self, epoch):
         network_filename = 'network_file_' + str(epoch) + '.pkl'
-        self._persist_network(network_filename)
+        #we no longer want to write the entire network, it's too enormous
+        #self._persist_network(network_filename)
 
     def start_testing(self, epoch):
         self.testing = True

--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -117,10 +117,11 @@ class NeuralAgent(AgentBase):
 
     def _open_params_file(self):
         self.params_file = open(self.export_dir + '/params.json', 'w')
-        param_list = [getattr(self.params, attr) \
-            for attr in dir(self.params) \
-            if isinstance(getattr(self.params, attr), (int, float, str))]
-        json.dump(param_list, self.params_file)
+        param_dict = {k:v for k, v in self.params.__dict__.items() \
+                      if "__" not in k \
+                      and isinstance(v, (int, float, str, bool))}
+        print(param_dict)
+        json.dump(param_dict, self.params_file, indent=4)
         self.params_file.close()
 
     def _open_results_file(self):

--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -314,8 +314,7 @@ class NeuralAgent(AgentBase):
 
     def finish_epoch(self, epoch):
         network_filename = 'network_file_' + str(epoch) + '.pkl'
-        #we no longer want to write the entire network, it's too enormous
-        #self._persist_network(network_filename)
+        self._persist_network(network_filename)
 
     def start_testing(self, epoch):
         self.testing = True

--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -10,6 +10,7 @@ import os
 import cPickle
 import time
 import logging
+import json
 
 import numpy as np
 
@@ -77,6 +78,7 @@ class NeuralAgent(AgentBase):
         self.last_action = None
 
         self.export_dir = self._create_export_dir()
+        self._open_params_file()
         self._open_results_file()
         self._open_learning_file()
 
@@ -112,6 +114,17 @@ class NeuralAgent(AgentBase):
             os.makedirs(export_dir)
 
         return export_dir
+
+    def _open_params_file(self):
+        self.params_file = open(self.export_dir + '/params.json', 'w')
+        param_list = [getattr(self.params, attr) \
+            for attr in dir(self.params) \
+            if isinstance(getattr(self.params, attr), (int, float, str))]
+        print(param_list, type(param_list))
+        for x in param_list:
+            print(type(x), isinstance(x, (int, float, str)))
+        json.dump(param_list, self.params_file)
+        self.params_file.close()
 
     def _open_results_file(self):
         logging.info("OPENING " + self.export_dir + '/results.csv')

--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -120,7 +120,6 @@ class NeuralAgent(AgentBase):
         param_dict = {k:v for k, v in self.params.__dict__.items() \
                       if "__" not in k \
                       and isinstance(v, (int, float, str, bool))}
-        print(param_dict)
         json.dump(param_dict, self.params_file, indent=4)
         self.params_file.close()
 


### PR DESCRIPTION
Because of json's structure it doesn't support serialization of anything other than "primitives" (so to speak - no such thing in python), necessitating conversion of the params object to a list containing only the serializable params, hence the weird list comprehension on line 120-122 of ale_agent.py.