### PR TITLE
record identifying information with each experiment

### DIFF
--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -15,6 +15,8 @@ import numpy as np
 
 import ale_data_set
 
+import pipes
+import subprocess
 import sys
 sys.setrecursionlimit(10000)
 
@@ -39,7 +41,7 @@ class NeuralAgent(object):
         self.image_height = self.network.input_height
 
         # CREATE A FOLDER TO HOLD RESULTS
-        time_str = time.strftime("_%m-%d-%H-%M_", time.gmtime())
+        time_str = time.strftime("_%m-%d-%H-%M-%S_", time.gmtime())
         self.exp_dir = self.exp_pref + time_str + \
                        "{}".format(self.network.lr).replace(".", "p") + "_" \
                        + "{}".format(self.network.discount).replace(".", "p")
@@ -48,6 +50,15 @@ class NeuralAgent(object):
             os.stat(self.exp_dir)
         except OSError:
             os.makedirs(self.exp_dir)
+
+        # Record command line and repository info.
+        with open(os.path.join(self.exp_dir, 'cmdline'), 'w') as f:
+            f.write(' '.join(pipes.quote(x) for x in sys.argv))
+            f.write('\n')
+        with open(os.path.join(self.exp_dir, 'git-status'), 'w') as f:
+            f.write(subprocess.check_output(['git', 'status']))
+        with open(os.path.join(self.exp_dir, 'git-diff'), 'w') as f:
+            f.write(subprocess.check_output(['git', 'diff', 'HEAD']))
 
         self.num_actions = self.network.num_actions
 

--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -55,6 +55,8 @@ class NeuralAgent(object):
         with open(os.path.join(self.exp_dir, 'cmdline'), 'w') as f:
             f.write(' '.join(pipes.quote(x) for x in sys.argv))
             f.write('\n')
+        with open(os.path.join(self.exp_dir, 'git-rev-parse'), 'w') as f:
+            f.write(subprocess.check_output(['git', 'rev-parse', 'HEAD']))
         with open(os.path.join(self.exp_dir, 'git-status'), 'w') as f:
             f.write(subprocess.check_output(['git', 'status']))
         with open(os.path.join(self.exp_dir, 'git-diff'), 'w') as f:

--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -57,8 +57,6 @@ class NeuralAgent(object):
             f.write('\n')
         with open(os.path.join(self.exp_dir, 'git-rev-parse'), 'w') as f:
             f.write(subprocess.check_output(['git', 'rev-parse', 'HEAD']))
-        with open(os.path.join(self.exp_dir, 'git-status'), 'w') as f:
-            f.write(subprocess.check_output(['git', 'status']))
         with open(os.path.join(self.exp_dir, 'git-diff'), 'w') as f:
             f.write(subprocess.check_output(['git', 'diff', 'HEAD']))
 


### PR DESCRIPTION
This makes it easier to keep track of experiment configuration and parameters automatically. Note that "git diff HEAD" will include both staged and unstaged changes.

Example:
```
~/dqn/test-runs/version_info_10-02-07-56-18_0p00025_0p99$ cat cmdline 
./run_nature.py --experiment-prefix /home/dsj/dqn/test-runs/version_info --rom breakout
~/dqn/test-runs/version_info_10-02-07-56-18_0p00025_0p99$ cat git-rev-parse 
71061e912c138c1a00bac65e41d15634e14f0585
~/dqn/test-runs/version_info_10-02-07-56-18_0p00025_0p99$ cat git-diff 
diff --git a/deep_q_rl/ale_agent.py b/deep_q_rl/ale_agent.py
index fc3b04b..ea0f5a8 100755
--- a/deep_q_rl/ale_agent.py
+++ b/deep_q_rl/ale_agent.py
@@ -57,8 +57,6 @@ class NeuralAgent(object):
             f.write('\n')
         with open(os.path.join(self.exp_dir, 'git-rev-parse'), 'w') as f:
             f.write(subprocess.check_output(['git', 'rev-parse', 'HEAD']))
-        with open(os.path.join(self.exp_dir, 'git-status'), 'w') as f:
-            f.write(subprocess.check_output(['git', 'status']))
         with open(os.path.join(self.exp_dir, 'git-diff'), 'w') as f:
             f.write(subprocess.check_output(['git', 'diff', 'HEAD']))
```