### PR TITLE
Implementation of Double DQN

### DIFF
--- a/deep_q_rl/ale_run_watch.py
+++ b/deep_q_rl/ale_run_watch.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 def run_watch():
-    command = ['./run_double.py', '--steps-per-epoch', '0',
+    command = ['./run_nature.py', '--steps-per-epoch', '0',
                '--test-length', '10000', '--nn-file', sys.argv[1],
                '--display-screen']
 

--- a/deep_q_rl/ale_run_watch.py
+++ b/deep_q_rl/ale_run_watch.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 def run_watch():
-    command = ['./run_nature.py', '--steps-per-epoch', '0',
+    command = ['./run_double.py', '--steps-per-epoch', '0',
                '--test-length', '10000', '--nn-file', sys.argv[1],
                '--display-screen']
 

--- a/deep_q_rl/launcher.py
+++ b/deep_q_rl/launcher.py
@@ -138,6 +138,10 @@ def process_args(args, defaults, description):
                         type=bool, default=defaults.CUDNN_DETERMINISTIC,
                         help=('Whether to use deterministic backprop. ' +
                               '(default: %(default)s)'))
+    parser.add_argument('--use_double', dest="use_double",
+                        type=bool, default=defaults.USE_DOUBLE,
+                        help=('Whether to use Double DQN. ' +
+                              '(default: %(default)s)'))
 
     parameters = parser.parse_args(args)
     if parameters.experiment_prefix is None:
@@ -216,6 +220,7 @@ def launch(args, defaults, description):
                                          parameters.momentum,
                                          parameters.clip_delta,
                                          parameters.freeze_interval,
+                                         parameters.use_double,
                                          parameters.batch_size,
                                          parameters.network_type,
                                          parameters.update_rule,

--- a/deep_q_rl/run_double.py
+++ b/deep_q_rl/run_double.py
@@ -60,7 +60,7 @@ class Defaults:
     MAX_START_NULLOPS = 30
     DETERMINISTIC = True
     CUDNN_DETERMINISTIC = False
-    USE_DOUBLE = False
+    USE_DOUBLE = True
 
 if __name__ == "__main__":
     launcher.launch(sys.argv[1:], Defaults, __doc__)

--- a/deep_q_rl/run_double.py
+++ b/deep_q_rl/run_double.py
@@ -3,8 +3,8 @@
 Execute a training run of deep-Q-Leaning with parameters that
 are consistent with:
 
-Human-level control through deep reinforcement learning.
-Nature, 518(7540):529-533, February 2015
+Deep Reinforcement Learning with Double Q-learning.
+arXiv preprint arXiv:1509.06461.
 
 """
 

--- a/deep_q_rl/run_nips.py
+++ b/deep_q_rl/run_nips.py
@@ -55,6 +55,7 @@ class Defaults:
     MAX_START_NULLOPS = 0
     DETERMINISTIC = True
     CUDNN_DETERMINISTIC = False
+    USE_DOUBLE = False
 
 if __name__ == "__main__":
     launcher.launch(sys.argv[1:], Defaults, __doc__)

--- a/deep_q_rl/test/test_q_network.py
+++ b/deep_q_rl/test/test_q_network.py
@@ -114,7 +114,7 @@ class LinearTests(unittest.TestCase):
                                      self.mdp.num_actions, 1,
                                      self.discount,
                                      self.learning_rate, 0, 0, 0, 0,
-                                     freeze_interval, 1, 'linear',
+                                     freeze_interval, False, 1, 'linear',
                                      'sgd', 'sum', 1.0)
 
         mdp = self.mdp
@@ -157,7 +157,7 @@ class LinearTests(unittest.TestCase):
                                      self.mdp.num_actions, 1,
                                      self.discount,
                                      self.learning_rate, 0, 0, 0, 0,
-                                     freeze_interval, 1, 'linear',
+                                     freeze_interval, False, 1, 'linear',
                                      'sgd', 'sum', 1.0)
 
 
@@ -178,7 +178,7 @@ class LinearTests(unittest.TestCase):
                                      self.mdp.num_actions, 1,
                                      self.discount,
                                      self.learning_rate, 0, 0, 0, 0,
-                                     freeze_interval, 1, 'linear',
+                                     freeze_interval, False, 1, 'linear',
                                      'sgd', 'sum', 1.0)
 
         # Randomize initial q-values:
@@ -203,7 +203,7 @@ class LinearTests(unittest.TestCase):
                                      self.mdp.num_actions, 1,
                                      self.discount,
                                      self.learning_rate, 0, 0, 0, 0,
-                                     freeze_interval, 1, 'linear',
+                                     freeze_interval, False, 1, 'linear',
                                      'sgd', 'sum', 1.0)
 
         self.train(net, 1000)
@@ -218,7 +218,7 @@ class LinearTests(unittest.TestCase):
                                      self.mdp.num_actions, 1,
                                      self.discount,
                                      self.learning_rate, 0, 0, 0, 0,
-                                     freeze_interval, 1, 'linear',
+                                     freeze_interval, False, 1, 'linear',
                                      'sgd', 'sum', 1.0)
 
         self.train(net, 1000)
@@ -233,7 +233,7 @@ class LinearTests(unittest.TestCase):
                                      self.mdp.num_actions, 1,
                                      self.discount,
                                      self.learning_rate, 0, 0, 0, 0,
-                                     freeze_interval, 1, 'linear',
+                                     freeze_interval, False, 1, 'linear',
                                      'sgd', 'sum', 1.0)
 
         self.train(net, freeze_interval * 2)


### PR DESCRIPTION
I was interested in implementing Double DQN in this source code, so here are my changes. Feel free to pull these into the main codebase. I didn't change much, since the Double DQN algorithm is not much different from that described in the Nature paper. I couldn't get the original tests to pass, so I was not able to add a test for Double DQN. I did test everything though, by running experiments with Breakout. Here is the performance over time:

![image](https://cloud.githubusercontent.com/assets/72242/11328659/bc389492-915c-11e5-8900-5a7e07ef459b.png)

Of course, the differences here are negligible and Breakout was named in the Double DQN paper as not having a real change under Double DQN. If I had more computing resources, I could test on the games which Double DQN makes a significant difference. Here is perhaps a more useful plot that shows how Double DQN seems to reduce value overestimates:

![image](https://cloud.githubusercontent.com/assets/72242/11328683/1ee7a6aa-915d-11e5-98f1-ece56bdc48b4.png)

And here is the change required for Double DQN:

![image](https://cloud.githubusercontent.com/assets/72242/11329109/38789720-9165-11e5-9f1f-697f85e52ba8.png)

If you don't have the time to look over the changes or to test them yourself, I understand. At least this PR will allow others to use it easily if need be.

References:

van Hasselt, H., Guez, A., & Silver, D. (2015). Deep Reinforcement Learning with Double Q-learning. arXiv preprint arXiv:1509.06461.
