### PR TITLE
We must choose the network when watching it play using the ale_run_watch.py script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ output.  You can plot the progress by executing `plot_results.py`:
 `$ python plot_results.py breakout_05-28-17-09_0p00025_0p99/results.csv`
 
 After training completes, you can watch the network play using the 
-`ale_run_watch.py` script: 
+`ale_run_watch.py` script. REMEMBER to select the network you used (nips or nature): 
 
-`$ python ale_run_watch.py breakout_05-28-17-09_0p00025_0p99/network_file_99.pkl`
+`$ python ale_run_watch.py nips breakout_05-28-17-09_0p00025_0p99/network_file_99.pkl`
+
+`$ python ale_run_watch.py nature breakout_05-28-17-09_0p00025_0p99/network_file_99.pkl`
 
 # Performance Tuning
 

--- a/deep_q_rl/ale_run_watch.py
+++ b/deep_q_rl/ale_run_watch.py
@@ -9,12 +9,20 @@ import subprocess
 import sys
 
 def run_watch():
-    command = ['./run_nature.py', '--steps-per-epoch', '0',
-               '--test-length', '10000', '--nn-file', sys.argv[1],
+    if sys.argv[1] == 'nips':
+        script = './run_nips.py'
+    elif sys.argv[1] == 'nature':
+        script = './run_nature.py'
+    else:
+        print 'Usage: python ale_run_watch.py NETWORK_THAT_YOU_TRAINED(nips/nature) NETWORK_PKL_FILE [ ROM ]'
+        exit(0)  
+
+    command = [script, '--steps-per-epoch', '0',
+               '--test-length', '10000', '--nn-file', sys.argv[2],
                '--display-screen']
 
-    if len(sys.argv) > 2:
-        command.extend(['--rom', sys.argv[2]])
+    if len(sys.argv) > 3:
+        command.extend(['--rom', sys.argv[3]])
 
     p1 = subprocess.Popen(command)
     


### PR DESCRIPTION
Added a sys.argv to  `ale_run_watch.py` to choose the network used to play, because this scripts runed the trained network only on the Nature network(`run_nature.py`). If I trained the network with the NIPS one, we won't see the agent play the game properly when running the `ale_run_watch.py` script. 

So I add a sys.argv(`nips/nature`) to `ale_run_watch.py` and add a little change in the `README.md`.

Please review it and see if it works. And please tell me if my English isn't good enough to make sense :)
